### PR TITLE
[bug-fix-user-search-input-limit] change input max length to 128 (was

### DIFF
--- a/src/Opg/Common/Model/Entity/Search.php
+++ b/src/Opg/Common/Model/Entity/Search.php
@@ -60,7 +60,7 @@ class Search implements EntityInterface, \IteratorAggregate
                                 'options' => array(
                                     'encoding' => 'UTF-8',
                                     'min'      => 2,
-                                    'max'      => 24,
+                                    'max'      => 128,
                                 ),
                             )
                         )

--- a/tests/OpgTest/Common/Model/Entity/SearchTest.php
+++ b/tests/OpgTest/Common/Model/Entity/SearchTest.php
@@ -141,10 +141,10 @@ class SearchTest extends \PHPUnit_Framework_TestCase
     public function testQueryMaximumValidationFailureWithMessage()
     {
         $data = array(
-            'query' => str_pad('xyz', 25, 'abc')
+            'query' => str_pad('xyz', 129, 'abc')
         );
 
-        $this->assertEquals(25, strlen($data['query']));
+        $this->assertEquals(129, strlen($data['query']));
 
         $this->search->exchangeArray($data);
 
@@ -155,7 +155,7 @@ class SearchTest extends \PHPUnit_Framework_TestCase
         $validationMessage = array(
             'errors' => array(
                 'query' => array(
-                    'stringLengthTooLong' => "The input is more than 24 characters long"
+                    'stringLengthTooLong' => "The input is more than 128 characters long"
                 )
             )
         );


### PR DESCRIPTION
change user search input max length to 128 (was 24). Bug was found when using an email address which has more 24 characters, it returns wrong result.
