### PR TITLE
[#APOLLO-4701][#SDV-464] Added Type annotation...

### DIFF
--- a/src/Opg/Core/Model/Entity/Assignable/AssignableComposite.php
+++ b/src/Opg/Core/Model/Entity/Assignable/AssignableComposite.php
@@ -54,6 +54,7 @@ abstract class AssignableComposite implements IsAssignee, \IteratorAggregate, Ha
     /**
      * @ORM\ManyToMany(targetEntity="Opg\Core\Model\Entity\Assignable\Team", mappedBy="members")
      * @var ArrayCollection
+     * @Type("ArrayCollection")
      * @Groups({"api-poa-list","api-task-list"})
      * @MaxDepth(3)
      */


### PR DESCRIPTION
... to AssignableComposite::teams to fix error which was blocking retrieval of 'locked' status from Devise
