### PR TITLE
Added abstract method and implementation to return the primary actor

### DIFF
--- a/src/Opg/Core/Model/Entity/CaseItem/CaseItem.php
+++ b/src/Opg/Core/Model/Entity/CaseItem/CaseItem.php
@@ -830,4 +830,9 @@ abstract class CaseItem extends LegalEntity implements CaseItemInterface, HasRag
     {
         return $this->repeatApplicationReference;
     }
+
+    /**
+     * @return Person
+     */
+    abstract public function getPrimaryActor();
 }

--- a/src/Opg/Core/Model/Entity/CaseItem/Deputyship/Deputyship.php
+++ b/src/Opg/Core/Model/Entity/CaseItem/Deputyship/Deputyship.php
@@ -224,6 +224,14 @@ abstract class Deputyship extends CaseItem implements HasStatusDate, HasCaseRecN
         return $this->client;
     }
 
+    /**
+     * @return Client
+     */
+    public function getPrimaryActor()
+    {
+        return $this->getClient();
+    }
+
 
     /**
      * @return \Opg\Common\Filter\BaseInputFilter

--- a/src/Opg/Core/Model/Entity/CaseItem/PowerOfAttorney/PowerOfAttorney.php
+++ b/src/Opg/Core/Model/Entity/CaseItem/PowerOfAttorney/PowerOfAttorney.php
@@ -762,6 +762,14 @@ abstract class PowerOfAttorney extends CaseItem implements HasNoticeGivenDate, H
     }
 
     /**
+     * @return Donor
+     */
+    public function getPrimaryActor()
+    {
+        return $this->getDonor();
+    }
+
+    /**
      * @param Donor $donor
      *
      * @return PowerOfAttorney

--- a/tests/OpgTest/Core/Model/Entity/CaseItem/CaseItemTest.php
+++ b/tests/OpgTest/Core/Model/Entity/CaseItem/CaseItemTest.php
@@ -33,6 +33,10 @@ class CaseItemStub extends CaseItem
 
     }
 
+    public function getPrimaryActor()
+    {
+        return null;
+    }
     /**
      * @param  Person $person
      *

--- a/tests/OpgTest/Core/Model/Entity/CaseItem/Deputyship/OrderTest.php
+++ b/tests/OpgTest/Core/Model/Entity/CaseItem/Deputyship/OrderTest.php
@@ -78,6 +78,11 @@ class OrderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->layDeputy->getClient() instanceof Client);
         $this->assertTrue($this->layDeputy->getDeputies() instanceof ArrayCollection);
         $this->assertTrue($this->layDeputy->getFeePayer() instanceof FeePayer);
+
+        $this->assertEquals(
+            $this->layDeputy->getClient(),
+            $this->layDeputy->getPrimaryActor()
+        );
     }
 
     public function testGetSetOrderStatus()

--- a/tests/OpgTest/Core/Model/Entity/CaseItem/PowerOfAttorney/LpaTest.php
+++ b/tests/OpgTest/Core/Model/Entity/CaseItem/PowerOfAttorney/LpaTest.php
@@ -84,6 +84,11 @@ class LpaTest extends \PHPUnit_Framework_TestCase
             'Opg\Core\Model\Entity\CaseActor\Donor',
             $this->lpa->getDonor()
         );
+
+        $this->assertEquals(
+            $this->lpa->getDonor(),
+            $this->lpa->getPrimaryActor()
+        );
     }
 
     public function testThrowsExceptionWhenTryingToPassBadObjectToSetDonor()


### PR DESCRIPTION
instead of if `$case instanceof Lpa` etc logic we can now do the following

`$case->getPrimaryActor()`

if it is an instance of an PowerOfAttorney this will return a Donor, if a Deputyship a client, people can still be added to cases via the abstract addPerson(Person $person) on case items