### PR TITLE
Set time to 0 explicitly

### DIFF
--- a/src/Opg/Core/Model/Entity/Task/Task.php
+++ b/src/Opg/Core/Model/Entity/Task/Task.php
@@ -352,6 +352,7 @@ class Task implements EntityInterface, \IteratorAggregate, HasRagRating, IsAssig
                                     'callback' => function ($value, $context = array()) {
                                             $dueDate = $value;
                                             $now     = new \DateTime();
+                                            $now->setTime(0, 0, 0);
 
                                             return $now <= $dueDate;
                                         }


### PR DESCRIPTION
Creating tasks would fail 1 in 10 times. The reasons for this is that now would sometimes be one-second ahead. Therefore the task endpoint would return a 400 for bad request. As the validator just needs to
check that now is either todays date or in the future I have removed the time from the Date Time. 